### PR TITLE
Fix: Not working on new Version of WPS

### DIFF
--- a/install.py
+++ b/install.py
@@ -58,7 +58,7 @@ XML_PATHS = {
     'publish': ADDON_PATH + os.path.sep + 'publish.xml',
     'authwebsite': ADDON_PATH + os.path.sep + 'authwebsite.xml'
 }
-PROXY_PATH = ADDON_PATH + os.path.sep + 'proxy.py'
+PROXY_PATH = ADDON_PATH + os.path.sep + APPNAME + os.path.sep + 'proxy.py'
 
 
 def uninstall():
@@ -163,6 +163,24 @@ if os.name == 'nt':
             with open(pref_fn, 'w') as f:
                 f.write(content)
 
+# Launch proxy.py on startup
+if os.name == 'nt':
+    print('Adding a task to run proxy.py on startup.')
+    cmd = 'pythonw.exe "{}"'.format(PROXY_PATH)
+    with open(os.environ['APPDATA'] + '\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\start_wps_zotero_proxy.bat', 'w') as f:
+        f.write("@echo off\n")
+        f.write(cmd)
+
+    # Start immediately after the installation
+    print('Starting proxy server for WPS-Zotero...')
+    try:
+        # In order for the script to continue, 
+        # set the timeout=0.1s, which actually runs in the background
+        subprocess.call(['pythonw.exe', PROXY_PATH], timeout=0.1)
+    except:
+        pass
+    
+    
 
 print('All done, enjoy!')
 print('(run ./install.py -u to uninstall)')

--- a/install.py
+++ b/install.py
@@ -170,16 +170,6 @@ if os.name == 'nt':
     with open(os.environ['APPDATA'] + '\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\start_wps_zotero_proxy.bat', 'w') as f:
         f.write("@echo off\n")
         f.write(cmd)
-
-    # Start immediately after the installation
-    print('Starting proxy server for WPS-Zotero...')
-    try:
-        # In order for the script to continue, 
-        # set the timeout=0.1s, which actually runs in the background
-        subprocess.call(['pythonw.exe', PROXY_PATH], timeout=0.1)
-    except:
-        pass
-    
     
 
 print('All done, enjoy!')

--- a/js/ribbon.js
+++ b/js/ribbon.js
@@ -48,9 +48,9 @@ function OnAddinLoad(ribbonUI) {
     }
     
     // Exit the proxy server when the application quits.
-    Application.ApiEvent.AddApiEventListener("ApplicationQuit", () => {
-        postRequestXHR('http://127.0.0.1:21931/stopproxy', null);
-    });
+    // Application.ApiEvent.AddApiEventListener("ApplicationQuit", () => {
+    //     postRequestXHR('http://127.0.0.1:21931/stopproxy', null);
+    // });
     
     return true;
 }

--- a/windows安装与卸载.bat
+++ b/windows安装与卸载.bat
@@ -21,7 +21,9 @@ SET /P choice=请输入您的选择（1、2或3）：
 if "%choice%"=="1" (
     echo. 开始安装
     python install.py
-    echo. 安装结束,请按任意键退出
+    echo. 安装结束,请直接关闭窗口
+    pythonw proxy.py
+    echo. 按任意键退出
     pause
 ) else if "%choice%"=="2" (
     echo. 开始卸载


### PR DESCRIPTION
根据 https://github.com/tankwyn/WPS-Zotero/issues/34 和 https://github.com/tankwyn/WPS-Zotero/issues/16 的讨论启发，在安装时实现开机自启动 proxy server，并且在WPS关闭后也不关闭proxy server，即proxy一直在后台运行。

优点：简单可行，一劳永逸（应该？

缺点：
- 首次安装时因为需要将脚本写入系统的 Start Up 文件夹，可能会触发杀毒软件误报
- 每次开机后会有一下黑窗口闪烁（启动脚本）
- 这个python程序在后台常驻，但理论上几乎不占用系统资源
