### PR TITLE
Fix "Client Error 400" by rewriting Host and Content-Type headers for Zotero 9

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -181,6 +181,27 @@ class ProxyServer:
                 s.sendall(data)
                 logging.info('responded to a preflight request')
                 return
+            
+            try:
+                head_text = head_raw.decode('utf8', errors='ignore')
+                # 1. Replace header to fix port mismatch
+                head_text = head_text.replace('21931', '23119')
+                # 2. Replace or add Content-Type
+                lines = head_text.split('\r\n')
+                found = False
+                for i in range(len(lines)):
+                    if lines[i].lower().startswith('content-type:'):
+                        lines[i] = 'Content-Type: application/json'
+                        found = True
+                        break
+                if not found:
+                    lines.insert(1, 'Content-Type: application/json')
+                head_text = '\r\n'.join(lines)
+                # 3. Reconstruct the data packet to send to Zotero
+                data = head_text.encode('utf8') + b'\r\n\r\n' + body_raw
+            except Exception as e:
+                logging.error('Header rewrite failed: {}'.format(e))
+
         else:
             logging.info('message received from zotero')
             # CORS

--- a/proxy.py
+++ b/proxy.py
@@ -184,21 +184,41 @@ class ProxyServer:
             
             try:
                 head_text = head_raw.decode('utf8', errors='ignore')
-                # 1. Replace header to fix port mismatch
-                head_text = head_text.replace('21931', '23119')
-                # 2. Replace or add Content-Type
+                
+                # 1. Clean the JSON body
+                body_clean = body_raw.strip()
+                
+                # 2. Rebuild headers
                 lines = head_text.split('\r\n')
-                found = False
-                for i in range(len(lines)):
-                    if lines[i].lower().startswith('content-type:'):
-                        lines[i] = 'Content-Type: application/json'
-                        found = True
-                        break
-                if not found:
-                    lines.insert(1, 'Content-Type: application/json')
-                head_text = '\r\n'.join(lines)
-                # 3. Reconstruct the data packet to send to Zotero
-                data = head_text.encode('utf8') + b'\r\n\r\n' + body_raw
+                new_lines = [lines[0]]
+                
+                for line in lines[1:]:
+                    if not line.strip(): continue
+                    lower_line = line.lower()
+                    
+                    # Strip headers
+                    if lower_line.startswith('host:') or \
+                       lower_line.startswith('content-length:') or \
+                       lower_line.startswith('content-type:') or \
+                       lower_line.startswith('origin:') or \
+                       lower_line.startswith('sec-'):
+                        continue
+                    new_lines.append(line)
+                
+                # 3. Inject Anti-CSRF headers and metadata
+                new_lines.append('Host: 127.0.0.1:23119')
+                new_lines.append('Content-Type: application/json')
+                new_lines.append('Content-Length: {}'.format(len(body_clean)))
+                new_lines.append('Origin: chrome-extension://ekhagklcjbdpajgpjgmbionohlpdbjgc')
+                new_lines.append('Zotero-Allowed-Request: true')
+                new_lines.append('Zotero-Connector-Version: 5.0.120')
+                new_lines.append('X-Zotero-Connector-API-Version: 2.0')
+                
+                head_text = '\r\n'.join(new_lines)
+                
+                # 4. Reconstruct data packet
+                data = head_text.encode('utf8') + b'\r\n\r\n' + body_clean
+                
             except Exception as e:
                 logging.error('Header rewrite failed: {}'.format(e))
 


### PR DESCRIPTION
After updating to latest version of Zotero and WPS, an error message "Client Error 400" will pop out when trying to add citations or references (this [#46](https://github.com/tankwyn/WPS-Zotero/issues/46) and also this [#47](https://github.com/tankwyn/WPS-Zotero/issues/47)). The new version of Zotero rejects the payload request due to HTTP header validation. So this PR should fix it by rewrite the HTTP headers right before it send the message over to Zotero. And also i have tried it on the newest Zotero 9 and it works great no lie 🤥.