### PR TITLE
fix: bypass Zotero 7.0.5+ browser-detection that blocks connector requests

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -130,12 +130,13 @@ class ProxyServer:
         clientsock, clientaddr = self.server.accept()
         self.clients.append(clientaddr)
         self.input_list.append(clientsock)
-        logging.info("{} has connected".format(clientaddr))
+        logging.info("Client {} has connected".format(clientaddr))
         forward = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             forward.connect(('127.0.0.1', ZOTERO_PORT))
+            logging.info("Successfully connected to Zotero on port {}".format(ZOTERO_PORT))
         except socket.error as e:
-            logging.warning("Cannot connect to Zotero, is the app started?")
+            logging.warning("Cannot connect to Zotero on port {} — is Zotero running?".format(ZOTERO_PORT))
             logging.debug("Failed to connect to Zotero: {}".format(e))
             forward.close()
             # NOTE: Cannot close client sockets here for it will discard quit commands.
@@ -181,6 +182,18 @@ class ProxyServer:
                 s.sendall(data)
                 logging.info('responded to a preflight request')
                 return
+            # Inject connector identity headers and scrub browser-origin headers
+            # to bypass Zotero's browser-detection security (added in Zotero 7.0.5+).
+            # Without these, Zotero silently closes the connection with _cancelResponse().
+            headers['X-Zotero-Connector-API-Version'] = '3'
+            headers['Zotero-Allowed-Request'] = '1'
+            headers['Host'] = '127.0.0.1:{}'.format(ZOTERO_PORT)
+            # Drop browser-origin headers that trigger Zotero's isBrowser check
+            headers.pop('Origin', None)
+            headers.pop('Sec-Fetch-Site', None)
+            headers.pop('Sec-Fetch-Mode', None)
+            headers.pop('Sec-Fetch-Dest', None)
+            data = '\r\n'.join([request] + [': '.join(h) for h in headers.items()] + ['', '']).encode('utf8') + body_raw
         else:
             logging.info('message received from zotero')
             # CORS
@@ -207,7 +220,18 @@ def main(argv):
     if len(argv) < 2:
         try:
             server = ProxyServer('127.0.0.1', PROXY_PORT)
-            logging.info('proxy started!')
+            logging.info('WPS-Zotero proxy v{} started on port {}'.format(
+                '0.1.2', PROXY_PORT))
+            # Quick check: is Zotero running?
+            try:
+                test_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                test_sock.settimeout(0.5)
+                test_sock.connect(('127.0.0.1', ZOTERO_PORT))
+                test_sock.close()
+                logging.info('Zotero is reachable on port {}'.format(ZOTERO_PORT))
+            except socket.error:
+                logging.warning('Zotero does not appear to be running on port {} — '
+                               'the proxy will start but requests will fail until Zotero is launched'.format(ZOTERO_PORT))
             atexit.register(lambda : logging.info('proxy stopped!'))
             server.run()
         except Exception as e:

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,16 @@
 
 A WPS Writer add-on for integrating with Zotero. **It supports both GNU/Linux and Windows now**. WPS is an office suite with excellent compatibility to MS Word. For scientific workers to migrate from Windows to GNU/Linux, lacking a good Word processor with citation management support has always been a great obstacle. With this add-on, you can add/edit citations in documents created with MS Word or send your documents created with WPS Writer to others to edit in MS Word. It should provide a seamless experience for people who work in an environment where everyone else use Windows and MS Word. If you encountered any problem, please open an issue, I will fix it ASAP.
 
+## Compatibility
+
+| Zotero 版本 | 状态 |
+|-------------|------|
+| 6.x | ✅ 支持 |
+| 7.0.0 ~ 7.0.5 | ✅ 支持 |
+| 7.0.5+ / 8.x / 9.x (最新) | ✅ v0.1.3 已修复 |
+
+> Zotero 7.0.5+ 新增了浏览器检测安全机制，会静默拦截来自 WPS 内嵌浏览器的 HTTP 请求。v0.1.3 修复了代理的请求头使其通过 Zotero 的身份验证。
+
 这个插件可以让你在Linux下写论文，再发给别人在Windows/MS Word下改，两边插入的引用可以共通（需要选择将引用存储为域）。**现在也支持Windows了哦**（Windows下有一些问题，翻到最后查看）。喜欢的朋友点个星星，帮忙散播一下消息，帮助更多科研狗逃脱Windows/MS Office！
 
 ## Installation
@@ -24,9 +34,21 @@ This add-on uses WPS's jsapi to control WPS Writer, and works with Zotero throug
 
 The add-on will store data to documents in a way similar as MS Word does. The only difference is that the `formattedCitation` in the field data is in XML format, while MS Word uses RTF format. However, this shouldn't pose any inconvenience for common users. Because Zotero will automatically update it for you. However, you should always store citations in fields rather than bookmarks, as the latter is not supported by this add-on.
 
+## Linux: 手动启动代理
+
+如果 WPS 无法自动启动代理（点击 Zotero 按钮没反应），手动运行：
+
+```bash
+cd ~/.local/share/Kingsoft/wps/jsaddons/wps-zotero_*/
+./start_proxy.sh          # 启动代理
+./start_proxy.sh status   # 检查状态
+```
+
 ## Common fixes
 
 If there's something wrong occurred during a transaction, the Zotero server will then be unusable, you will then be advised to restart Zotero. For other cases, restart WPS Writer and Zotero to see if the problem persists. If the problem persists, you can run `python proxy.py kill` in the package directory to quit the proxy server manually before restarting the applications. Re-installation can be tried of course if you still can't fix it.
+
+To check the proxy log: `cat ~/.wps-zotero-proxy.log`
 
 ## Known issues
 

--- a/start_proxy.sh
+++ b/start_proxy.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# WPS-Zotero Proxy 手动启动脚本 (Linux)
+# 当 WPS 无法自动启动代理时使用此脚本
+#
+# 使用方法：
+#   启动:  ./start_proxy.sh
+#   停止:  ./start_proxy.sh kill
+#
+# 也可以设置开机自启：
+#   cp start_proxy.sh ~/.config/autostart/wps-zotero-proxy.sh
+#   或添加到 crontab: @reboot /path/to/start_proxy.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROXY="$SCRIPT_DIR/proxy.py"
+PIDFILE="/tmp/wps-zotero-proxy.pid"
+LOGFILE="$HOME/.wps-zotero-proxy.log"
+
+case "${1:-start}" in
+    start)
+        # 检查是否已在运行
+        if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+            echo "代理已在运行 (PID: $(cat "$PIDFILE"))"
+            exit 0
+        fi
+
+        # 先杀掉旧实例
+        python3 "$PROXY" kill 2>/dev/null || true
+        sleep 0.5
+
+        # 后台启动
+        nohup python3 "$PROXY" > /dev/null 2>&1 &
+        PID=$!
+        echo $PID > "$PIDFILE"
+        sleep 1
+
+        if kill -0 "$PID" 2>/dev/null; then
+            echo "WPS-Zotero 代理已启动 (PID: $PID)"
+            echo "日志文件: $LOGFILE"
+            echo "注意：请确保 Zotero 已运行"
+        else
+            echo "启动失败！请检查日志: $LOGFILE"
+            rm -f "$PIDFILE"
+            exit 1
+        fi
+        ;;
+    kill|stop)
+        python3 "$PROXY" kill 2>/dev/null || true
+        rm -f "$PIDFILE"
+        echo "代理已停止"
+        ;;
+    status)
+        if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+            echo "代理运行中 (PID: $(cat "$PIDFILE"))"
+            # 检查 Zotero 是否在运行
+            if python3 -c "import socket; s=socket.socket(); s.settimeout(0.5); s.connect(('127.0.0.1',23119)); s.close(); print('Zotero 可达')" 2>/dev/null; then
+                echo "Zotero 可达 : OK"
+            else
+                echo "Zotero 可达 : 无法连接 (Zotero 可能未启动)"
+            fi
+        else
+            echo "代理未运行"
+        fi
+        ;;
+    *)
+        echo "用法: $0 {start|stop|kill|status}"
+        exit 1
+        ;;
+esac

--- a/version.js
+++ b/version.js
@@ -1,2 +1,2 @@
-const VERSION = '0.1.2'
+const VERSION = '0.1.3'
 


### PR DESCRIPTION
## 问题

Zotero 7.0.5+ 新增了浏览器检测安全机制（`server.js` 中的 `_cancelResponse()`），会静默关闭来自浏览器的 HTTP 请求。WPS 内嵌 Chromium 发出的请求带 `User-Agent: Mozilla/...` 和 `Origin` 头，经代理原样转发到 Zotero 后被拦截，表现为 "Network error occurred, is Zotero running?"。

Fixes #47, fixes #52

## 修复

修改 `proxy.py`，在转发客户端请求到 Zotero 前：

1. 注入 `X-Zotero-Connector-API-Version: 3` 和 `Zotero-Allowed-Request: 1` 头
2. 删除 `Origin`、`Sec-Fetch-*` 等浏览器特征头
3. 修正 `Host` 头指向 Zotero 端口 (23119)

另外增加了：
- 代理启动时 Zotero 可达性诊断日志
- Linux 手动启动代理脚本 `start_proxy.sh`（WPS ShellExecute 在 Linux 上可能不可靠）

## 测试

已在 Zotero 9.0.4 + Ubuntu 22.04 + WPS 12.x 上端到端验证通过。
